### PR TITLE
feat: Installer support under sudo mode with enchancements.

### DIFF
--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -36,7 +36,7 @@ connotice Downloading FiveM Server
 wget -O /var/fivem/fx.tar.xz 'https://runtime.fivem.net/artifacts/fivem/build_proot_linux/master/$FIVEM_ARTIFACT_VERSION/fx.tar.xz'
 
 coninfo Extracting data from downloaded files
-tar -xzvf fx.tar.xz
+tar -xvf fx.tar.xz
 rm fx.tar.xz
 
 # Install GIT
@@ -50,7 +50,7 @@ sudo mv ./cfx-server-data/resources /var/fivem
 
 # Create configuration file
 conlog Creating server.cfg
-sudo bash -c "cat > server.cfg << EOF
+sudo bash -c "cat > /var/fivem/server.cfg << EOF
 # Only change the IP if you're using a server with multiple network interfaces, otherwise change the port only.
 endpoint_add_tcp "0.0.0.0:30120"
 endpoint_add_udp "0.0.0.0:30120"
@@ -153,8 +153,7 @@ conwarn Creating FiveM server start script
 sudo bash -c "cat > /usr/bin/fivem_startserver << EOF
 #!/bin/bash
 tmux new-session -d -s 'FiveM_Server'
-tmux send-keys -t FiveM_Server 'cd /var/fivem' Enter
-tmux send-keys -t FiveM_Server './run.sh +exec server.cfg' Enter
+tmux send-keys -t FiveM_Server '/var/fivem/run.sh +exec /var/fivem/server.cfg' Enter
 EOF"
 sudo chmod +x /usr/bin/fivem_startserver
 
@@ -175,8 +174,7 @@ sudo rm /usr/bin/fivem_startserver
 sudo bash -c \"cat > /usr/bin/fivem_startserver << EOT
 #!/bin/bash
 tmux new-session -d -s 'FiveM_Server'
-tmux send-keys -t FiveM_Server 'cd /var/fivem' Enter
-tmux send-keys -t FiveM_Server './run.sh' Enter
+tmux send-keys -t FiveM_Server '/var/fivem/run.sh' Enter
 EOT\"
 sudo chmod +x /usr/bin/fivem_startserver
 sudo systemctl restart fivem
@@ -191,8 +189,7 @@ sudo rm /usr/bin/fivem_startserver
 sudo bash -c \"cat > /usr/bin/fivem_startserver << 'EOT'
 #!/bin/bash
 tmux new-session -d -s 'FiveM_Server'
-tmux send-keys -t FiveM_Server 'cd /var/fivem' Enter
-tmux send-keys -t FiveM_Server './run.sh +exec server.cfg' Enter
+tmux send-keys -t FiveM_Server '/var/fivem/run.sh +exec /var/fivem/server.cfg' Enter
 EOT\"
 sudo chmod +x /usr/bin/fivem_startserver
 sudo systemctl restart fivem
@@ -209,10 +206,9 @@ sudo systemctl enable fivem
 
 # Cleanup
 coninfo Cleaning up
-cd /var/fivem
 sudo rm -rf cubeshostvpsservice* cubeshostinstaller.zip cfx-server-data
 
-sleep 1
+sleep 3
 
 # Start service
 conlog Starting FiveM Server

--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -172,12 +172,12 @@ conwarn Creating FiveM txAdmin enable script
 sudo bash -c "cat > /usr/bin/fivem_txadminenable << EOF
 #!/bin/bash
 sudo rm /usr/bin/fivem_startserver
-sudo bash -c 'cat > /usr/bin/fivem_startserver << 'EOT'
+sudo bash -c "cat > /usr/bin/fivem_startserver << EOT
 #!/bin/bash
 sudo tmux new-session -d -s 'FiveM_Server'
 sudo tmux send-keys -t FiveM_Server 'cd ~' Enter
 sudo tmux send-keys -t FiveM_Server './run.sh' Enter
-EOT'
+EOT"
 sudo chmod +x /usr/bin/fivem_startserver
 sudo systemctl restart fivem
 EOF"
@@ -188,12 +188,12 @@ conwarn Creating FiveM txAdmin disable script
 sudo bash -c "cat > /usr/bin/fivem_txadmindisable << EOF
 #!/bin/bash
 sudo rm /usr/bin/fivem_startserver
-sudo bash -c 'cat > /usr/bin/fivem_startserver << 'EOT'
+sudo bash -c "cat > /usr/bin/fivem_startserver << 'EOT'
 #!/bin/bash
 sudo tmux new-session -d -s 'FiveM_Server'
 sudo tmux send-keys -t FiveM_Server 'cd ~' Enter
 sudo tmux send-keys -t FiveM_Server './run.sh +exec server.cfg' Enter
-EOT'
+EOT"
 sudo chmod +x /usr/bin/fivem_startserver
 sudo systemctl restart fivem
 EOF"

--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -227,4 +227,15 @@ printf "
     Port: 30120
 ──────────────────────────────
 
-# C
+# Commands to start, stop and restart server from VPS. #
+  • Start
+    sudo systemctl start fivem
+  • Stop
+    sudo systemctl stop fivem
+  • Restart
+    sudo systemctl restart fivem
+  • Status
+    sudo systemctl status fivem
+# Note: Server Control Panel (txAdmin) is disabled by default, to enable please run 'fivem_txadminenable' and use 'tmux a -t FiveM_Server' to get the passcode to login with txAdmin.
+# Follow our knowledgebase article for assistance:
+"

--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -3,7 +3,6 @@
 INSTALLER_SCRIPT='cubeshostvpsservice*/installer/main.sh'
 . $INSTALLER_SCRIPT
 
-reset
 checkRoot
 conlogo
 writeLog NOTICE 96 true Starting up script..
@@ -37,7 +36,7 @@ cd /var/fivem
 wget 'https://runtime.fivem.net/artifacts/fivem/build_proot_linux/master/$FIVEM_ARTIFACT_VERSION/fx.tar.xz'
 
 coninfo Extracting data from downloaded files
-tar -xvf fx.tar.xz
+tar -xzvf fx.tar.xz
 rm fx.tar.xz
 
 # Install GIT
@@ -48,7 +47,7 @@ sudo apt-get install git -y
 connotice Downloading cfx-server-data
 cd /var/fivem
 git clone https://github.com/citizenfx/cfx-server-data
-sudo mv ~/cfx-server-data/resources ~
+sudo mv ./cfx-server-data/resources /var/fivem
 
 # Create configuration file
 conlog Creating server.cfg
@@ -155,7 +154,7 @@ conwarn Creating FiveM server start script
 sudo bash -c "cat > /usr/bin/fivem_startserver << EOF
 #!/bin/bash
 tmux new-session -d -s 'FiveM_Server'
-tmux send-keys -t FiveM_Server 'cd ~' Enter
+tmux send-keys -t FiveM_Server 'cd /var/fivem' Enter
 tmux send-keys -t FiveM_Server './run.sh +exec server.cfg' Enter
 EOF"
 sudo chmod +x /usr/bin/fivem_startserver
@@ -177,7 +176,7 @@ sudo rm /usr/bin/fivem_startserver
 sudo bash -c \"cat > /usr/bin/fivem_startserver << EOT
 #!/bin/bash
 tmux new-session -d -s 'FiveM_Server'
-tmux send-keys -t FiveM_Server 'cd ~' Enter
+tmux send-keys -t FiveM_Server 'cd /var/fivem' Enter
 tmux send-keys -t FiveM_Server './run.sh' Enter
 EOT\"
 sudo chmod +x /usr/bin/fivem_startserver
@@ -193,7 +192,7 @@ sudo rm /usr/bin/fivem_startserver
 sudo bash -c \"cat > /usr/bin/fivem_startserver << 'EOT'
 #!/bin/bash
 tmux new-session -d -s 'FiveM_Server'
-tmux send-keys -t FiveM_Server 'cd ~' Enter
+tmux send-keys -t FiveM_Server 'cd /var/fivem' Enter
 tmux send-keys -t FiveM_Server './run.sh +exec server.cfg' Enter
 EOT\"
 sudo chmod +x /usr/bin/fivem_startserver

--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -154,7 +154,7 @@ conwarn Creating FiveM server start script
 sudo bash -c "cat > /usr/bin/fivem_startserver << EOF
 #!/bin/bash
 tmux new-session -d -s "FiveM_Server"
-tmux send-keys -t FiveM_Server "cd /root" Enter
+tmux send-keys -t FiveM_Server "cd ~" Enter
 tmux send-keys -t FiveM_Server "./run.sh +exec server.cfg" Enter
 EOF"
 sudo chmod +x /usr/bin/fivem_startserver
@@ -172,13 +172,13 @@ sudo chmod +x /usr/bin/fivem_stopserver
 conwarn Creating FiveM txAdmin enable script
 sudo bash -c "cat > /usr/bin/fivem_txadminenable << EOF
 #!/bin/bash
-rm /usr/bin/fivem_startserver
-cat > /usr/bin/fivem_startserver << EOT
+sudo rm /usr/bin/fivem_startserver
+sudo bash -c "cat > /usr/bin/fivem_startserver << EOT
 #!/bin/bash
 tmux new-session -d -s "FiveM_Server"
 tmux send-keys -t FiveM_Server "cd /root" Enter
 tmux send-keys -t FiveM_Server "./run.sh" Enter
-EOT
+EOT"
 chmod +x /usr/bin/fivem_startserver
 systemctl restart fivem
 EOF"
@@ -188,13 +188,13 @@ sudo chmod +x /usr/bin/fivem_txadminenable
 conwarn Creating FiveM txAdmin disable script
 sudo bash -c "cat > /usr/bin/fivem_txadmindisable << EOF
 #!/bin/bash
-rm /usr/bin/fivem_startserver
-cat > /usr/bin/fivem_startserver << EOT
+sudo rm /usr/bin/fivem_startserver
+sudo bash -c "cat > /usr/bin/fivem_startserver << EOT
 #!/bin/bash
 tmux new-session -d -s "FiveM_Server"
 tmux send-keys -t FiveM_Server "cd /root" Enter
 tmux send-keys -t FiveM_Server "./run.sh +exec server.cfg" Enter
-EOT
+EOT"
 chmod +x /usr/bin/fivem_startserver
 systemctl restart fivem
 EOF"

--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ### Main Installer ###
-INSTALLER_SCRIPT="cubeshostvpsservice-master/installer/main.sh"
+INSTALLER_SCRIPT="cubeshostvpsservice-stable/installer/main.sh"
 . $INSTALLER_SCRIPT
 
 checkRoot
@@ -37,7 +37,7 @@ coninfo Extracting data from downloaded files
 tar -xvf fx.tar.xz
 rm fx.tar.xz
 
-# Install GIT 
+# Install GIT
 coninfo Installing git
 apt-get install git -y
 
@@ -79,7 +79,7 @@ sets tags "default"
 
 # A valid locale identifier for your server's primary language.
 # For example "en-US", "fr-CA", "nl-NL", "de-DE", "en-GB", "pt-BR"
-sets locale "root-AQ" 
+sets locale "root-AQ"
 # please DO replace root-AQ on the line ABOVE with a real language! :)
 
 # Set an optional server info and connecting banner image url.
@@ -131,14 +131,14 @@ EOF
 # Create systemd service file
 conwarn Setting up server for starting during boot
 cat > /lib/systemd/system/fivem.service << EOF
-[Unit] 
-Description=FiveM Server 
+[Unit]
+Description=FiveM Server
 
 [Service]
 Type=forking
 User=root
-ExecStart=/usr/bin/fivem_startserver.sh
-ExecStop=/usr/bin/fivem_stopserver.sh
+ExecStart=/usr/bin/fivem_startserver
+ExecStop=/usr/bin/fivem_stopserver
 
 [Install]
 WantedBy=multi-user.target
@@ -150,54 +150,54 @@ apt-get install tmux -y
 
 # FiveM start script
 conwarn Creating FiveM server start script
-cat > /usr/bin/fivem_startserver.sh << EOF
+cat > /usr/bin/fivem_startserver << EOF
 #!/bin/bash
 tmux new-session -d -s "FiveM_Server"
 tmux send-keys -t FiveM_Server "cd /root" Enter
 tmux send-keys -t FiveM_Server "./run.sh +exec server.cfg" Enter
 EOF
-chmod +x /usr/bin/fivem_startserver.sh
+chmod +x /usr/bin/fivem_startserver
 
 # FiveM stop script
 conwarn Creating FiveM server stop script
-cat > /usr/bin/fivem_stopserver.sh << EOF
+cat > /usr/bin/fivem_stopserver << EOF
 #!/bin/bash
 tmux send-keys -t FiveM_Server C-c
 tmux kill-session -t "FiveM_Server"
 EOF
-chmod +x /usr/bin/fivem_stopserver.sh
+chmod +x /usr/bin/fivem_stopserver
 
 # FiveM txAdmin Enable script
 conwarn Creating FiveM txAdmin enable script
-cat > /usr/bin/fivem_txadminenable.sh << EOF
+cat > /usr/bin/fivem_txadminenable << EOF
 #!/bin/bash
-rm /usr/bin/fivem_startserver.sh
-cat > /usr/bin/fivem_startserver.sh << EOT
+rm /usr/bin/fivem_startserver
+cat > /usr/bin/fivem_startserver << EOT
 #!/bin/bash
 tmux new-session -d -s "FiveM_Server"
 tmux send-keys -t FiveM_Server "cd /root" Enter
 tmux send-keys -t FiveM_Server "./run.sh" Enter
 EOT
-chmod +x /usr/bin/fivem_startserver.sh
+chmod +x /usr/bin/fivem_startserver
 systemctl restart fivem
 EOF
-chmod +x /usr/bin/fivem_txadminenable.sh
+chmod +x /usr/bin/fivem_txadminenable
 
 # FiveM txAdmin Disable script
 conwarn Creating FiveM txAdmin disable script
-cat > /usr/bin/fivem_txadmindisable.sh << EOF
+cat > /usr/bin/fivem_txadmindisable << EOF
 #!/bin/bash
-rm /usr/bin/fivem_startserver.sh
-cat > /usr/bin/fivem_startserver.sh << EOT
+rm /usr/bin/fivem_startserver
+cat > /usr/bin/fivem_startserver << EOT
 #!/bin/bash
 tmux new-session -d -s "FiveM_Server"
 tmux send-keys -t FiveM_Server "cd /root" Enter
 tmux send-keys -t FiveM_Server "./run.sh +exec server.cfg" Enter
 EOT
-chmod +x /usr/bin/fivem_startserver.sh
+chmod +x /usr/bin/fivem_startserver
 systemctl restart fivem
 EOF
-chmod +x /usr/bin/fivem_txadmindisable.sh
+chmod +x /usr/bin/fivem_txadmindisable
 
 # Reload systemd daemon
 conemergency Reloading systemd daemon
@@ -210,7 +210,7 @@ systemctl enable fivem
 # Cleanup
 coninfo Cleaning up
 cd ~
-rm -rf cubeshostvpsservice-master master.zip cfx-server-data
+rm -rf cubeshostvpsservice-stable stable.zip cfx-server-data
 
 sleep 1
 
@@ -240,10 +240,10 @@ printf "
 
   • Restart
     systemctl restart fivem
-    
+
   • Status
     systemctl status fivem
 
-# Note: Server Control Panel (txAdmin) is disabled by default, to enable please run 'fivem_txadminenable.sh' and use 'tmux a -t FiveM_Server' to get the passcode to login with txAdmin.
-# Follow our knowledgebase article for assistance: 
+# Note: Server Control Panel (txAdmin) is disabled by default, to enable please run 'fivem_txadminenable' and use 'tmux a -t FiveM_Server' to get the passcode to login with txAdmin.
+# Follow our knowledgebase article for assistance:
 "

--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -169,7 +169,7 @@ sudo chmod +x /usr/bin/fivem_stopserver
 
 # FiveM txAdmin Enable script
 conwarn Creating FiveM txAdmin enable script
-sudo bash -c "cat > /usr/bin/fivem_txadminenable << 'EOF'
+sudo bash -c "cat > /usr/bin/fivem_txadminenable << EOF
 #!/bin/bash
 sudo rm /usr/bin/fivem_startserver
 sudo bash -c 'cat > /usr/bin/fivem_startserver << 'EOT'
@@ -177,17 +177,15 @@ sudo bash -c 'cat > /usr/bin/fivem_startserver << 'EOT'
 sudo tmux new-session -d -s 'FiveM_Server'
 sudo tmux send-keys -t FiveM_Server 'cd ~' Enter
 sudo tmux send-keys -t FiveM_Server './run.sh' Enter
-EOT
-'
+EOT'
 sudo chmod +x /usr/bin/fivem_startserver
 sudo systemctl restart fivem
-EOF
-"
+EOF"
 sudo chmod +x /usr/bin/fivem_txadminenable
 
 # FiveM txAdmin Disable script
 conwarn Creating FiveM txAdmin disable script
-sudo bash -c "cat > /usr/bin/fivem_txadmindisable << 'EOF'
+sudo bash -c "cat > /usr/bin/fivem_txadmindisable << EOF
 #!/bin/bash
 sudo rm /usr/bin/fivem_startserver
 sudo bash -c 'cat > /usr/bin/fivem_startserver << 'EOT'
@@ -195,12 +193,10 @@ sudo bash -c 'cat > /usr/bin/fivem_startserver << 'EOT'
 sudo tmux new-session -d -s 'FiveM_Server'
 sudo tmux send-keys -t FiveM_Server 'cd ~' Enter
 sudo tmux send-keys -t FiveM_Server './run.sh +exec server.cfg' Enter
-EOT
-'
+EOT'
 sudo chmod +x /usr/bin/fivem_startserver
 sudo systemctl restart fivem
-EOF
-"
+EOF"
 sudo chmod +x /usr/bin/fivem_txadmindisable
 
 # Reload systemd daemon

--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 ### Main Installer ###
-INSTALLER_SCRIPT="cubeshostvpsservice-stable/installer/main.sh"
+INSTALLER_SCRIPT="cubeshostvpsservice*/installer/main.sh"
 . $INSTALLER_SCRIPT
 
 checkRoot
 conlogo
 connotice Starting up script..
-sleep 5
+sleep 3
 
 ### FiveM Installer ###
 FIVEM_ARTIFACT_VERSION=4394-572b000db3f5a323039e0915dac64641d1db408e
@@ -49,7 +49,7 @@ sudo mv ~/cfx-server-data/resources ~
 
 # Create configuration file
 conlog Creating server.cfg
-cat > server.cfg << EOF
+sudo bash -c "cat > server.cfg << EOF
 # Only change the IP if you're using a server with multiple network interfaces, otherwise change the port only.
 endpoint_add_tcp "0.0.0.0:30120"
 endpoint_add_udp "0.0.0.0:30120"
@@ -126,11 +126,11 @@ set steam_webApiKey ""
 
 # License key for your server (https://keymaster.fivem.net)
 sv_licenseKey changeme
-EOF
+EOF"
 
 # Create systemd service file
 conwarn Setting up server for starting during boot
-sudo cat > /lib/systemd/system/fivem.service << EOF
+sudo bash -c "cat > /lib/systemd/system/fivem.service << EOF
 [Unit]
 Description=FiveM Server
 
@@ -142,7 +142,7 @@ ExecStop=/usr/bin/fivem_stopserver
 
 [Install]
 WantedBy=multi-user.target
-EOF
+EOF"
 
 # Install TMUX
 coninfo Installing tmux
@@ -150,26 +150,26 @@ sudo apt-get install tmux -y
 
 # FiveM start script
 conwarn Creating FiveM server start script
-sudo cat > /usr/bin/fivem_startserver << EOF
+sudo bash -c "cat > /usr/bin/fivem_startserver << EOF
 #!/bin/bash
 tmux new-session -d -s "FiveM_Server"
 tmux send-keys -t FiveM_Server "cd /root" Enter
 tmux send-keys -t FiveM_Server "./run.sh +exec server.cfg" Enter
-EOF
+EOF"
 sudo chmod +x /usr/bin/fivem_startserver
 
 # FiveM stop script
 conwarn Creating FiveM server stop script
-sudo cat > /usr/bin/fivem_stopserver << EOF
+sudo bash -c "cat > /usr/bin/fivem_stopserver << EOF
 #!/bin/bash
 tmux send-keys -t FiveM_Server C-c
 tmux kill-session -t "FiveM_Server"
-EOF
+EOF"
 sudo chmod +x /usr/bin/fivem_stopserver
 
 # FiveM txAdmin Enable script
 conwarn Creating FiveM txAdmin enable script
-sudo cat > /usr/bin/fivem_txadminenable << EOF
+sudo bash -c "cat > /usr/bin/fivem_txadminenable << EOF
 #!/bin/bash
 rm /usr/bin/fivem_startserver
 cat > /usr/bin/fivem_startserver << EOT
@@ -180,12 +180,12 @@ tmux send-keys -t FiveM_Server "./run.sh" Enter
 EOT
 chmod +x /usr/bin/fivem_startserver
 systemctl restart fivem
-EOF
+EOF"
 sudo chmod +x /usr/bin/fivem_txadminenable
 
 # FiveM txAdmin Disable script
 conwarn Creating FiveM txAdmin disable script
-sudo cat > /usr/bin/fivem_txadmindisable << EOF
+sudo bash -c "cat > /usr/bin/fivem_txadmindisable << EOF
 #!/bin/bash
 rm /usr/bin/fivem_startserver
 cat > /usr/bin/fivem_startserver << EOT
@@ -196,7 +196,7 @@ tmux send-keys -t FiveM_Server "./run.sh +exec server.cfg" Enter
 EOT
 chmod +x /usr/bin/fivem_startserver
 systemctl restart fivem
-EOF
+EOF"
 sudo chmod +x /usr/bin/fivem_txadmindisable
 
 # Reload systemd daemon
@@ -210,7 +210,7 @@ sudo systemctl enable fivem
 # Cleanup
 coninfo Cleaning up
 cd ~
-sudo rm -rf cubeshostvpsservice-stable stable.zip cfx-server-data
+sudo rm -rf cubeshostvpsservice* cubeshostinstaller.zip cfx-server-data
 
 sleep 1
 

--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -6,27 +6,27 @@ INSTALLER_SCRIPT="cubeshostvpsservice-stable/installer/main.sh"
 checkRoot
 conlogo
 connotice Starting up script..
-sleep 3
+sleep 5
 
 ### FiveM Installer ###
 FIVEM_ARTIFACT_VERSION=4394-572b000db3f5a323039e0915dac64641d1db408e
 
 coninfo Updating and upgrading apt
-apt-get update -y && apt-get upgrade -y
+sudo apt-get update -y && sudo apt-get upgrade -y
 
 # Install & Setup UFW Firewall
 coninfo Installing and setting up firewall
-apt-get install ufw -y
+sudo apt-get install ufw -y
 echo 'y' | ufw enable
-ufw allow OpenSSH
-ufw allow 30110
-ufw allow 30120
-ufw allow 40120
-ufw reload
+sudo ufw allow OpenSSH
+sudo ufw allow 30110
+sudo ufw allow 30120
+sudo ufw allow 40120
+sudo ufw reload
 
 # Install WGET
 coninfo Setting up wget
-apt-get install wget -y
+sudo apt-get install wget -y
 
 # Download FiveM Server
 connotice Downloading FiveM Server
@@ -39,13 +39,13 @@ rm fx.tar.xz
 
 # Install GIT
 coninfo Installing git
-apt-get install git -y
+sudo apt-get install git -y
 
 # Download cfx-server-data
 connotice Downloading cfx-server-data
 cd ~
 git clone https://github.com/citizenfx/cfx-server-data
-mv ~/cfx-server-data/resources ~
+sudo mv ~/cfx-server-data/resources ~
 
 # Create configuration file
 conlog Creating server.cfg
@@ -130,7 +130,7 @@ EOF
 
 # Create systemd service file
 conwarn Setting up server for starting during boot
-cat > /lib/systemd/system/fivem.service << EOF
+sudo cat > /lib/systemd/system/fivem.service << EOF
 [Unit]
 Description=FiveM Server
 
@@ -146,30 +146,30 @@ EOF
 
 # Install TMUX
 coninfo Installing tmux
-apt-get install tmux -y
+sudo apt-get install tmux -y
 
 # FiveM start script
 conwarn Creating FiveM server start script
-cat > /usr/bin/fivem_startserver << EOF
+sudo cat > /usr/bin/fivem_startserver << EOF
 #!/bin/bash
 tmux new-session -d -s "FiveM_Server"
 tmux send-keys -t FiveM_Server "cd /root" Enter
 tmux send-keys -t FiveM_Server "./run.sh +exec server.cfg" Enter
 EOF
-chmod +x /usr/bin/fivem_startserver
+sudo chmod +x /usr/bin/fivem_startserver
 
 # FiveM stop script
 conwarn Creating FiveM server stop script
-cat > /usr/bin/fivem_stopserver << EOF
+sudo cat > /usr/bin/fivem_stopserver << EOF
 #!/bin/bash
 tmux send-keys -t FiveM_Server C-c
 tmux kill-session -t "FiveM_Server"
 EOF
-chmod +x /usr/bin/fivem_stopserver
+sudo chmod +x /usr/bin/fivem_stopserver
 
 # FiveM txAdmin Enable script
 conwarn Creating FiveM txAdmin enable script
-cat > /usr/bin/fivem_txadminenable << EOF
+sudo cat > /usr/bin/fivem_txadminenable << EOF
 #!/bin/bash
 rm /usr/bin/fivem_startserver
 cat > /usr/bin/fivem_startserver << EOT
@@ -181,11 +181,11 @@ EOT
 chmod +x /usr/bin/fivem_startserver
 systemctl restart fivem
 EOF
-chmod +x /usr/bin/fivem_txadminenable
+sudo chmod +x /usr/bin/fivem_txadminenable
 
 # FiveM txAdmin Disable script
 conwarn Creating FiveM txAdmin disable script
-cat > /usr/bin/fivem_txadmindisable << EOF
+sudo cat > /usr/bin/fivem_txadmindisable << EOF
 #!/bin/bash
 rm /usr/bin/fivem_startserver
 cat > /usr/bin/fivem_startserver << EOT
@@ -197,29 +197,29 @@ EOT
 chmod +x /usr/bin/fivem_startserver
 systemctl restart fivem
 EOF
-chmod +x /usr/bin/fivem_txadmindisable
+sudo chmod +x /usr/bin/fivem_txadmindisable
 
 # Reload systemd daemon
 conemergency Reloading systemd daemon
-systemctl daemon-reload
+sudo systemctl daemon-reload
 
 # Enable service file
 connotice Enabling fivem service on boot
-systemctl enable fivem
+sudo systemctl enable fivem
 
 # Cleanup
 coninfo Cleaning up
 cd ~
-rm -rf cubeshostvpsservice-stable stable.zip cfx-server-data
+sudo rm -rf cubeshostvpsservice-stable stable.zip cfx-server-data
 
 sleep 1
 
 # Start service
 conlog Starting FiveM Server
-systemctl start fivem
+sudo systemctl start fivem
 
 # Final message
-VPS_IP=$( hostname -I | cut -f2 -d' ' )
+VPS_IP=$( sudo hostname -I | awk '{print $1}' )
 printf "
 # Server successfully created and ready for use.
 # Please add in the license key and other crucial information to get it ready and then restart the server.
@@ -233,16 +233,16 @@ printf "
 
 # Commands to start, stop and restart server from VPS. #
   • Start
-    systemctl start fivem
+    sudo systemctl start fivem
 
   • Stop
-    systemctl stop fivem
+    sudo systemctl stop fivem
 
   • Restart
-    systemctl restart fivem
+    sudo systemctl restart fivem
 
   • Status
-    systemctl status fivem
+    sudo systemctl status fivem
 
 # Note: Server Control Panel (txAdmin) is disabled by default, to enable please run 'fivem_txadminenable' and use 'tmux a -t FiveM_Server' to get the passcode to login with txAdmin.
 # Follow our knowledgebase article for assistance:

--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ### Main Installer ###
-INSTALLER_SCRIPT="cubeshostvpsservice*/installer/main.sh"
+INSTALLER_SCRIPT='cubeshostvpsservice*/installer/main.sh'
 . $INSTALLER_SCRIPT
 
 reset
@@ -32,7 +32,7 @@ sudo apt-get install wget -y
 # Download FiveM Server
 connotice Downloading FiveM Server
 cd ~
-wget "https://runtime.fivem.net/artifacts/fivem/build_proot_linux/master/$FIVEM_ARTIFACT_VERSION/fx.tar.xz"
+wget 'https://runtime.fivem.net/artifacts/fivem/build_proot_linux/master/$FIVEM_ARTIFACT_VERSION/fx.tar.xz'
 
 coninfo Extracting data from downloaded files
 tar -xvf fx.tar.xz
@@ -153,9 +153,9 @@ sudo apt-get install tmux -y
 conwarn Creating FiveM server start script
 sudo bash -c "cat > /usr/bin/fivem_startserver << EOF
 #!/bin/bash
-tmux new-session -d -s "FiveM_Server"
-tmux send-keys -t FiveM_Server "cd ~" Enter
-tmux send-keys -t FiveM_Server "./run.sh +exec server.cfg" Enter
+tmux new-session -d -s 'FiveM_Server'
+tmux send-keys -t FiveM_Server 'cd ~' Enter
+tmux send-keys -t FiveM_Server './run.sh +exec server.cfg' Enter
 EOF"
 sudo chmod +x /usr/bin/fivem_startserver
 
@@ -164,7 +164,7 @@ conwarn Creating FiveM server stop script
 sudo bash -c "cat > /usr/bin/fivem_stopserver << EOF
 #!/bin/bash
 tmux send-keys -t FiveM_Server C-c
-tmux kill-session -t "FiveM_Server"
+tmux kill-session -t 'FiveM_Server'
 EOF"
 sudo chmod +x /usr/bin/fivem_stopserver
 
@@ -173,12 +173,12 @@ conwarn Creating FiveM txAdmin enable script
 sudo bash -c "cat > /usr/bin/fivem_txadminenable << EOF
 #!/bin/bash
 sudo rm /usr/bin/fivem_startserver
-sudo bash -c "cat > /usr/bin/fivem_startserver << EOT
+sudo bash -c 'cat > /usr/bin/fivem_startserver << EOT
 #!/bin/bash
-tmux new-session -d -s "FiveM_Server"
-tmux send-keys -t FiveM_Server "cd /root" Enter
-tmux send-keys -t FiveM_Server "./run.sh" Enter
-EOT"
+tmux new-session -d -s 'FiveM_Server'
+tmux send-keys -t FiveM_Server 'cd ~' Enter
+tmux send-keys -t FiveM_Server './run.sh' Enter
+EOT'
 chmod +x /usr/bin/fivem_startserver
 systemctl restart fivem
 EOF"
@@ -189,12 +189,12 @@ conwarn Creating FiveM txAdmin disable script
 sudo bash -c "cat > /usr/bin/fivem_txadmindisable << EOF
 #!/bin/bash
 sudo rm /usr/bin/fivem_startserver
-sudo bash -c "cat > /usr/bin/fivem_startserver << EOT
+sudo bash -c 'cat > /usr/bin/fivem_startserver << EOT
 #!/bin/bash
-tmux new-session -d -s "FiveM_Server"
-tmux send-keys -t FiveM_Server "cd /root" Enter
-tmux send-keys -t FiveM_Server "./run.sh +exec server.cfg" Enter
-EOT"
+tmux new-session -d -s 'FiveM_Server'
+tmux send-keys -t FiveM_Server 'cd ~' Enter
+tmux send-keys -t FiveM_Server './run.sh +exec server.cfg' Enter
+EOT'
 chmod +x /usr/bin/fivem_startserver
 systemctl restart fivem
 EOF"

--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -169,34 +169,38 @@ sudo chmod +x /usr/bin/fivem_stopserver
 
 # FiveM txAdmin Enable script
 conwarn Creating FiveM txAdmin enable script
-sudo bash -c "cat > /usr/bin/fivem_txadminenable << EOF
+sudo bash -c "cat > /usr/bin/fivem_txadminenable << 'EOF'
 #!/bin/bash
 sudo rm /usr/bin/fivem_startserver
-sudo bash -c 'cat > /usr/bin/fivem_startserver << EOT
+sudo bash -c 'cat > /usr/bin/fivem_startserver << 'EOT'
 #!/bin/bash
 sudo tmux new-session -d -s 'FiveM_Server'
 sudo tmux send-keys -t FiveM_Server 'cd ~' Enter
 sudo tmux send-keys -t FiveM_Server './run.sh' Enter
-EOT'
+EOT
+'
 sudo chmod +x /usr/bin/fivem_startserver
 sudo systemctl restart fivem
-EOF"
+EOF
+"
 sudo chmod +x /usr/bin/fivem_txadminenable
 
 # FiveM txAdmin Disable script
 conwarn Creating FiveM txAdmin disable script
-sudo bash -c "cat > /usr/bin/fivem_txadmindisable << EOF
+sudo bash -c "cat > /usr/bin/fivem_txadmindisable << 'EOF'
 #!/bin/bash
 sudo rm /usr/bin/fivem_startserver
-sudo bash -c 'cat > /usr/bin/fivem_startserver << EOT
+sudo bash -c 'cat > /usr/bin/fivem_startserver << 'EOT'
 #!/bin/bash
 sudo tmux new-session -d -s 'FiveM_Server'
 sudo tmux send-keys -t FiveM_Server 'cd ~' Enter
 sudo tmux send-keys -t FiveM_Server './run.sh +exec server.cfg' Enter
-EOT'
+EOT
+'
 sudo chmod +x /usr/bin/fivem_startserver
 sudo systemctl restart fivem
-EOF"
+EOF
+"
 sudo chmod +x /usr/bin/fivem_txadmindisable
 
 # Reload systemd daemon

--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -137,7 +137,6 @@ Description=FiveM Server
 
 [Service]
 Type=forking
-User=root
 ExecStart=/usr/bin/fivem_startserver
 ExecStop=/usr/bin/fivem_stopserver
 
@@ -153,9 +152,9 @@ sudo apt-get install tmux -y
 conwarn Creating FiveM server start script
 sudo bash -c "cat > /usr/bin/fivem_startserver << EOF
 #!/bin/bash
-tmux new-session -d -s 'FiveM_Server'
-tmux send-keys -t FiveM_Server 'cd ~' Enter
-tmux send-keys -t FiveM_Server './run.sh +exec server.cfg' Enter
+sudo tmux new-session -d -s 'FiveM_Server'
+sudo tmux send-keys -t FiveM_Server 'cd ~' Enter
+sudo tmux send-keys -t FiveM_Server './run.sh +exec server.cfg' Enter
 EOF"
 sudo chmod +x /usr/bin/fivem_startserver
 
@@ -163,8 +162,8 @@ sudo chmod +x /usr/bin/fivem_startserver
 conwarn Creating FiveM server stop script
 sudo bash -c "cat > /usr/bin/fivem_stopserver << EOF
 #!/bin/bash
-tmux send-keys -t FiveM_Server C-c
-tmux kill-session -t 'FiveM_Server'
+sudo tmux send-keys -t FiveM_Server C-c
+sudo tmux kill-session -t 'FiveM_Server'
 EOF"
 sudo chmod +x /usr/bin/fivem_stopserver
 
@@ -175,12 +174,12 @@ sudo bash -c "cat > /usr/bin/fivem_txadminenable << EOF
 sudo rm /usr/bin/fivem_startserver
 sudo bash -c 'cat > /usr/bin/fivem_startserver << EOT
 #!/bin/bash
-tmux new-session -d -s 'FiveM_Server'
-tmux send-keys -t FiveM_Server 'cd ~' Enter
-tmux send-keys -t FiveM_Server './run.sh' Enter
+sudo tmux new-session -d -s 'FiveM_Server'
+sudo tmux send-keys -t FiveM_Server 'cd ~' Enter
+sudo tmux send-keys -t FiveM_Server './run.sh' Enter
 EOT'
-chmod +x /usr/bin/fivem_startserver
-systemctl restart fivem
+sudo chmod +x /usr/bin/fivem_startserver
+sudo systemctl restart fivem
 EOF"
 sudo chmod +x /usr/bin/fivem_txadminenable
 
@@ -191,12 +190,12 @@ sudo bash -c "cat > /usr/bin/fivem_txadmindisable << EOF
 sudo rm /usr/bin/fivem_startserver
 sudo bash -c 'cat > /usr/bin/fivem_startserver << EOT
 #!/bin/bash
-tmux new-session -d -s 'FiveM_Server'
-tmux send-keys -t FiveM_Server 'cd ~' Enter
-tmux send-keys -t FiveM_Server './run.sh +exec server.cfg' Enter
+sudo tmux new-session -d -s 'FiveM_Server'
+sudo tmux send-keys -t FiveM_Server 'cd ~' Enter
+sudo tmux send-keys -t FiveM_Server './run.sh +exec server.cfg' Enter
 EOT'
-chmod +x /usr/bin/fivem_startserver
-systemctl restart fivem
+sudo chmod +x /usr/bin/fivem_startserver
+sudo systemctl restart fivem
 EOF"
 sudo chmod +x /usr/bin/fivem_txadmindisable
 

--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -206,7 +206,7 @@ sudo systemctl enable fivem
 
 # Cleanup
 coninfo Cleaning up
-sudo rm -rf cubeshostvpsservice* cubeshostinstaller.zip cfx-server-data
+sudo rm -rf ~/cubeshostvpsservice* ~/cubeshostinstaller.zip cfx-server-data
 
 sleep 3
 

--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -33,7 +33,7 @@ sudo apt-get install wget -y
 # Download FiveM Server
 connotice Downloading FiveM Server
 cd /var/fivem
-wget 'https://runtime.fivem.net/artifacts/fivem/build_proot_linux/master/$FIVEM_ARTIFACT_VERSION/fx.tar.xz'
+wget -O /var/fivem/fx.tar.xz 'https://runtime.fivem.net/artifacts/fivem/build_proot_linux/master/$FIVEM_ARTIFACT_VERSION/fx.tar.xz'
 
 coninfo Extracting data from downloaded files
 tar -xzvf fx.tar.xz

--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -7,6 +7,8 @@ reset
 checkRoot
 conlogo
 writeLog NOTICE 96 true Starting up script..
+sudo mkdir -p /var/fivem
+sudo chmod ugo+rwx /var/fivem
 sleep 5
 
 ### FiveM Installer ###
@@ -31,7 +33,7 @@ sudo apt-get install wget -y
 
 # Download FiveM Server
 connotice Downloading FiveM Server
-cd ~
+cd /var/fivem
 wget 'https://runtime.fivem.net/artifacts/fivem/build_proot_linux/master/$FIVEM_ARTIFACT_VERSION/fx.tar.xz'
 
 coninfo Extracting data from downloaded files
@@ -44,7 +46,7 @@ sudo apt-get install git -y
 
 # Download cfx-server-data
 connotice Downloading cfx-server-data
-cd ~
+cd /var/fivem
 git clone https://github.com/citizenfx/cfx-server-data
 sudo mv ~/cfx-server-data/resources ~
 
@@ -209,7 +211,7 @@ sudo systemctl enable fivem
 
 # Cleanup
 coninfo Cleaning up
-cd ~
+cd /var/fivem
 sudo rm -rf cubeshostvpsservice* cubeshostinstaller.zip cfx-server-data
 
 sleep 1

--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -172,12 +172,12 @@ conwarn Creating FiveM txAdmin enable script
 sudo bash -c "cat > /usr/bin/fivem_txadminenable << EOF
 #!/bin/bash
 sudo rm /usr/bin/fivem_startserver
-sudo bash -c "cat > /usr/bin/fivem_startserver << EOT
+sudo bash -c \"cat > /usr/bin/fivem_startserver << EOT
 #!/bin/bash
 sudo tmux new-session -d -s 'FiveM_Server'
 sudo tmux send-keys -t FiveM_Server 'cd ~' Enter
 sudo tmux send-keys -t FiveM_Server './run.sh' Enter
-EOT"
+EOT\"
 sudo chmod +x /usr/bin/fivem_startserver
 sudo systemctl restart fivem
 EOF"
@@ -188,12 +188,12 @@ conwarn Creating FiveM txAdmin disable script
 sudo bash -c "cat > /usr/bin/fivem_txadmindisable << EOF
 #!/bin/bash
 sudo rm /usr/bin/fivem_startserver
-sudo bash -c "cat > /usr/bin/fivem_startserver << 'EOT'
+sudo bash -c \"cat > /usr/bin/fivem_startserver << 'EOT'
 #!/bin/bash
 sudo tmux new-session -d -s 'FiveM_Server'
 sudo tmux send-keys -t FiveM_Server 'cd ~' Enter
 sudo tmux send-keys -t FiveM_Server './run.sh +exec server.cfg' Enter
-EOT"
+EOT\"
 sudo chmod +x /usr/bin/fivem_startserver
 sudo systemctl restart fivem
 EOF"

--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -33,7 +33,7 @@ sudo apt-get install wget -y
 
 # Download FiveM Server
 connotice Downloading FiveM Server
-wget -O /var/fivem/fx.tar.xz 'https://runtime.fivem.net/artifacts/fivem/build_proot_linux/master/$FIVEM_ARTIFACT_VERSION/fx.tar.xz'
+wget -O /var/fivem/fx.tar.xz https://runtime.fivem.net/artifacts/fivem/build_proot_linux/master/$FIVEM_ARTIFACT_VERSION/fx.tar.xz
 
 coninfo Extracting data from downloaded files
 tar -xvf fx.tar.xz

--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -8,6 +8,7 @@ conlogo
 writeLog NOTICE 96 true Starting up script..
 sudo mkdir -p /var/fivem
 sudo chmod ugo+rwx /var/fivem
+cd /var/fivem
 sleep 5
 
 ### FiveM Installer ###
@@ -32,7 +33,6 @@ sudo apt-get install wget -y
 
 # Download FiveM Server
 connotice Downloading FiveM Server
-cd /var/fivem
 wget -O /var/fivem/fx.tar.xz 'https://runtime.fivem.net/artifacts/fivem/build_proot_linux/master/$FIVEM_ARTIFACT_VERSION/fx.tar.xz'
 
 coninfo Extracting data from downloaded files
@@ -45,7 +45,6 @@ sudo apt-get install git -y
 
 # Download cfx-server-data
 connotice Downloading cfx-server-data
-cd /var/fivem
 git clone https://github.com/citizenfx/cfx-server-data
 sudo mv ./cfx-server-data/resources /var/fivem
 
@@ -232,19 +231,4 @@ printf "
     Port: 30120
 ──────────────────────────────
 
-# Commands to start, stop and restart server from VPS. #
-  • Start
-    sudo systemctl start fivem
-
-  • Stop
-    sudo systemctl stop fivem
-
-  • Restart
-    sudo systemctl restart fivem
-
-  • Status
-    sudo systemctl status fivem
-
-# Note: Server Control Panel (txAdmin) is disabled by default, to enable please run 'fivem_txadminenable' and use 'tmux a -t FiveM_Server' to get the passcode to login with txAdmin.
-# Follow our knowledgebase article for assistance:
-"
+# C

--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -152,9 +152,9 @@ sudo apt-get install tmux -y
 conwarn Creating FiveM server start script
 sudo bash -c "cat > /usr/bin/fivem_startserver << EOF
 #!/bin/bash
-sudo tmux new-session -d -s 'FiveM_Server'
-sudo tmux send-keys -t FiveM_Server 'cd ~' Enter
-sudo tmux send-keys -t FiveM_Server './run.sh +exec server.cfg' Enter
+tmux new-session -d -s 'FiveM_Server'
+tmux send-keys -t FiveM_Server 'cd ~' Enter
+tmux send-keys -t FiveM_Server './run.sh +exec server.cfg' Enter
 EOF"
 sudo chmod +x /usr/bin/fivem_startserver
 
@@ -162,8 +162,8 @@ sudo chmod +x /usr/bin/fivem_startserver
 conwarn Creating FiveM server stop script
 sudo bash -c "cat > /usr/bin/fivem_stopserver << EOF
 #!/bin/bash
-sudo tmux send-keys -t FiveM_Server C-c
-sudo tmux kill-session -t 'FiveM_Server'
+tmux send-keys -t FiveM_Server C-c
+tmux kill-session -t 'FiveM_Server'
 EOF"
 sudo chmod +x /usr/bin/fivem_stopserver
 
@@ -174,9 +174,9 @@ sudo bash -c "cat > /usr/bin/fivem_txadminenable << EOF
 sudo rm /usr/bin/fivem_startserver
 sudo bash -c \"cat > /usr/bin/fivem_startserver << EOT
 #!/bin/bash
-sudo tmux new-session -d -s 'FiveM_Server'
-sudo tmux send-keys -t FiveM_Server 'cd ~' Enter
-sudo tmux send-keys -t FiveM_Server './run.sh' Enter
+tmux new-session -d -s 'FiveM_Server'
+tmux send-keys -t FiveM_Server 'cd ~' Enter
+tmux send-keys -t FiveM_Server './run.sh' Enter
 EOT\"
 sudo chmod +x /usr/bin/fivem_startserver
 sudo systemctl restart fivem
@@ -190,9 +190,9 @@ sudo bash -c "cat > /usr/bin/fivem_txadmindisable << EOF
 sudo rm /usr/bin/fivem_startserver
 sudo bash -c \"cat > /usr/bin/fivem_startserver << 'EOT'
 #!/bin/bash
-sudo tmux new-session -d -s 'FiveM_Server'
-sudo tmux send-keys -t FiveM_Server 'cd ~' Enter
-sudo tmux send-keys -t FiveM_Server './run.sh +exec server.cfg' Enter
+tmux new-session -d -s 'FiveM_Server'
+tmux send-keys -t FiveM_Server 'cd ~' Enter
+tmux send-keys -t FiveM_Server './run.sh +exec server.cfg' Enter
 EOT\"
 sudo chmod +x /usr/bin/fivem_startserver
 sudo systemctl restart fivem

--- a/games/fivem/installer.sh
+++ b/games/fivem/installer.sh
@@ -3,10 +3,11 @@
 INSTALLER_SCRIPT="cubeshostvpsservice*/installer/main.sh"
 . $INSTALLER_SCRIPT
 
+reset
 checkRoot
 conlogo
-connotice Starting up script..
-sleep 3
+writeLog NOTICE 96 true Starting up script..
+sleep 5
 
 ### FiveM Installer ###
 FIVEM_ARTIFACT_VERSION=4394-572b000db3f5a323039e0915dac64641d1db408e

--- a/installer/main.sh
+++ b/installer/main.sh
@@ -1,44 +1,47 @@
 writeLog() {
-  clear
-  parsedData=("${@:3} ")
+  if [[ $3 == true ]]; then
+    clear
+  fi
+  
+  parsedData=("${@:4} ")
   printf "\033[0m#\033[0;4m\033[0;1m\033[0;${2}m${1}\033[0m: ${parsedData[*]}\n\n"
   sleep 1
 }
 
 conlog() {
-  writeLog LOG 92 $*
+  writeLog LOG 92 true $*
 }
 
 coninfo() {
-  writeLog INFO 97 $*
+  writeLog INFO 97 true $*
 }
 
 connotice() {
-  writeLog NOTICE 96 $*
+  writeLog NOTICE 96 true $*
 }
 
 conwarn() {
-  writeLog WARN 93 $*
+  writeLog WARN 93 true $*
 }
 
 conalert() {
-  writeLog ALERT 36 $*
+  writeLog ALERT 36 true $*
 }
 
 concritical() {
-  writeLog CRITICAL 95 $*
+  writeLog CRITICAL 95 true $*
 }
 
 conemergency() {
-  writeLog EMERGENCY 41 $*
+  writeLog EMERGENCY 41 true $*
 }
 
 conerror() {
-  writeLog ERROR 98 $*
+  writeLog ERROR 98 true $*
 }
 
 condebug() {
-  writeLog DEBUG 92 $*
+  writeLog DEBUG 92 true $*
 }
 
 conlogo() {

--- a/installer/main.sh
+++ b/installer/main.sh
@@ -42,8 +42,7 @@ condebug() {
 }
 
 conlogo() {
-  echo -e "/*
- *  
+  echo -e "/*  
  * 
  * ┏━━━┓╋╋┏┓╋╋╋╋╋╋╋╋┏┓╋┏┓╋╋╋╋╋┏┓
  * ┃┏━┓┃╋╋┃┃╋╋╋╋╋╋╋╋┃┃╋┃┃╋╋╋╋┏┛┗┓
@@ -51,9 +50,6 @@ conlogo() {
  * ┃┃╋┏┫┃┃┃┏┓┃┃━┫━━┫┃┏━┓┃┏┓┃━━┫┃
  * ┃┗━┛┃┗┛┃┗┛┃┃━╋━━┣┫┃╋┃┃┗┛┣━━┃┗┓
  * ┗━━━┻━━┻━━┻━━┻━━┻┻┛╋┗┻━━┻━━┻━┛
- *
- * Quick and easy installer scripts for VPS service.
- * Visit https://github.com/sharletp/cubeshostvpsservice for more information.
  *
  * Copyright ©️ 2021 Cubes Hosting - All Rights Reserved.
  *

--- a/installer/main.sh
+++ b/installer/main.sh
@@ -1,6 +1,6 @@
 writeLog() {
   if [[ $3 == true ]]; then
-    clear
+    reset
   fi
   
   parsedData=("${@:4} ")


### PR DESCRIPTION
**The pull request includes the following changes:**
- Properly support **sudo** privileged execution of installer.
- Internal support for optional arguments that clears console.
- Usage of `reset` rather than `clear` for stagnant console logging.
- Support any branch installation as compared to just stable.
- Revamped and linted fivem installer.
- FiveM installer directory chosen as **/var/fivem** with full permissions given to all users for ease of maintainability.